### PR TITLE
fix: use nodemailer createTransport

### DIFF
--- a/src/email-service-server.ts
+++ b/src/email-service-server.ts
@@ -25,7 +25,7 @@ export class ServerEmailService {
 
   private initializeTransporter() {
     try {
-      this.transporter = nodemailer.createTransporter({
+      this.transporter = nodemailer.createTransport({
         service: 'gmail',
         auth: {
           user: this.config.gmailUser,


### PR DESCRIPTION
## Summary
- use `nodemailer.createTransport` instead of deprecated `createTransporter` in server email service

## Testing
- `npm test` (fails: Failed to connect to localhost port 3000)
- `node -e "const nodemailer=require('nodemailer'); const transporter=nodemailer.createTransport({jsonTransport:true}); transporter.sendMail({from:'test@example.com', to:'dest@example.com', subject:'hello', text:'hi'}, (err, info)=>{ console.log('err', err); console.log('info', info); });"`

------
https://chatgpt.com/codex/tasks/task_e_68b7cdacdc8083258c3c02bc54803110